### PR TITLE
add empty `Package.swift`

### DIFF
--- a/Example/Package.swift
+++ b/Example/Package.swift
@@ -1,0 +1,9 @@
+// swift-tools-version: 5.7
+
+import PackageDescription
+
+let package = Package(
+    name: ""
+    products: [ ],
+    targets: []
+)


### PR DESCRIPTION
Add an empty `Package.swift`  file to the Example folder to exclude it from the package target folder